### PR TITLE
Stream features

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 {cover_enabled, true}.
 {deps, [
-        {exml, "2.1.5", {git, "git://github.com/esl/exml.git", "2.1.5"}},
+        {exml, ".*", {git, "git://github.com/esl/exml.git", "8e20ac4e6f7a1d1179cc011a4d9d095974766bcc"}},
         {proper, ".*", {git, "git://github.com/manopapad/proper.git", "fa58f82bdc35e20"}},
-        {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}},  
+        {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}},
         {p1_stringprep, ".*", {git, "git://github.com/processone/stringprep.git", "9e9e0f8dbe6"}}
        ]}.
 {erl_opts, [warnings_as_errors]}.

--- a/src/x.erl
+++ b/src/x.erl
@@ -1,3 +1,5 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x).
 
 -export_type([iso_639_1_lang/0]).

--- a/src/x_addressable.erl
+++ b/src/x_addressable.erl
@@ -1,3 +1,5 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_addressable).
 
 -export([from/1, to/1]).

--- a/src/x_contract.erl
+++ b/src/x_contract.erl
@@ -9,7 +9,7 @@ check(Val, Pred) ->
     true -> ok;
     Other -> fail(Val, Pred, Other)
   catch E:R ->
-          fail(Val, Pred, {E,R})
+          fail(Val, Pred, {E, R})
   end.
 
 -spec fail(any(), fun((any())->boolean()), any()) -> no_return().

--- a/src/x_contract.erl
+++ b/src/x_contract.erl
@@ -1,15 +1,17 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_contract).
 -export([check/2]).
 
 -spec check(any(), fun((any())->boolean())) -> ok.
 check(Val, Pred) ->
-    try Pred(Val) of
-        true -> ok;
-        Other -> fail(Val, Pred, Other)
-    catch E:R ->
-            fail(Val, Pred, {E,R})
-    end.
+  try Pred(Val) of
+    true -> ok;
+    Other -> fail(Val, Pred, Other)
+  catch E:R ->
+          fail(Val, Pred, {E,R})
+  end.
 
 -spec fail(any(), fun((any())->boolean()), any()) -> no_return().
 fail(Value, Predicate, PredicateResult) ->
-    error({contract_failed, Value, {Predicate, PredicateResult}}).
+  error({contract_failed, Value, {Predicate, PredicateResult}}).

--- a/src/x_exmlable.erl
+++ b/src/x_exmlable.erl
@@ -7,8 +7,8 @@
 -export([to_exmlel/1]).
 
 %% xmlstreamelement - both xmlel and streams start/stop
--callback to_exmlel(any()) -> xmlstreamelement().
+-callback to_exmlel(any()) -> exml_stream:element().
 
--spec to_exmlel(tuple()) -> xmlstreamelement().
+-spec to_exmlel(tuple()) -> exml_stream:element().
 to_exmlel(Xmlable) ->
   (x_implementation:module(Xmlable)):to_exmlel(Xmlable).

--- a/src/x_exmlable.erl
+++ b/src/x_exmlable.erl
@@ -1,3 +1,5 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_exmlable).
 
 -include_lib("exml/include/exml_stream.hrl").
@@ -9,4 +11,4 @@
 
 -spec to_exmlel(tuple()) -> xmlstreamelement().
 to_exmlel(Xmlable) ->
-    (x_implementation:module(Xmlable)):to_exmlel(Xmlable).
+  (x_implementation:module(Xmlable)):to_exmlel(Xmlable).

--- a/src/x_implementation.erl
+++ b/src/x_implementation.erl
@@ -1,3 +1,5 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_implementation).
 
 -export([module/1]).

--- a/src/x_jid.erl
+++ b/src/x_jid.erl
@@ -62,9 +62,9 @@ new(User, Domain) ->
 
 -spec to_bin(jid()) -> binary().
 to_bin(#full_jid{username = U, domain = D, resource = R}) ->
-  <<(maybe_user_at(U))/binary,D/binary,"/",R/binary>>;
+  <<(maybe_user_at(U))/binary, D/binary, "/", R/binary>>;
 to_bin(#bare_jid{username = U, domain = D}) ->
-  <<(maybe_user_at(U))/binary,D/binary>>.
+  <<(maybe_user_at(U))/binary, D/binary>>.
 
 -spec from_bin(binary()) -> jid().
 from_bin(Bin) when is_binary(Bin) ->
@@ -113,8 +113,8 @@ has_same_domain(JID1, JID2) ->
 parse_jid_elements(Bin) ->
   [User, Rest] = parse_user_part(Bin),
   case binary:split(Rest, <<"/">>, [global]) of
-    [Domain] -> {User,Domain};
-    [Domain, Resource] -> {User,Domain,Resource};
+    [Domain] -> {User, Domain};
+    [Domain, Resource] -> {User, Domain, Resource};
     _ -> throw(malformed_jid)
   end.
 

--- a/src/x_jid.erl
+++ b/src/x_jid.erl
@@ -1,3 +1,5 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_jid).
 
 -export([new/2, new/3]).
@@ -47,29 +49,29 @@ is_jid(_) -> false.
 
 -spec new(username(), domain(), resource()) -> full_jid().
 new(User, Domain, Resource) ->
-    x_contract:check(User, fun is_binary/1),
-    x_contract:check(Domain, fun is_binary/1),
-    x_contract:check(Resource, fun is_binary/1),
-    #full_jid{username = User, domain = Domain, resource = Resource}.
+  x_contract:check(User, fun is_binary/1),
+  x_contract:check(Domain, fun is_binary/1),
+  x_contract:check(Resource, fun is_binary/1),
+  #full_jid{username = User, domain = Domain, resource = Resource}.
 
 -spec new(username(), domain()) -> bare_jid().
 new(User, Domain) ->
-    x_contract:check(User, fun is_binary/1),
-    x_contract:check(Domain, fun is_binary/1),
-    #bare_jid{username = User, domain = Domain}.
+  x_contract:check(User, fun is_binary/1),
+  x_contract:check(Domain, fun is_binary/1),
+  #bare_jid{username = User, domain = Domain}.
 
 -spec to_bin(jid()) -> binary().
 to_bin(#full_jid{username = U, domain = D, resource = R}) ->
-    <<(maybe_user_at(U))/binary,D/binary,"/",R/binary>>;
+  <<(maybe_user_at(U))/binary,D/binary,"/",R/binary>>;
 to_bin(#bare_jid{username = U, domain = D}) ->
-    <<(maybe_user_at(U))/binary,D/binary>>.
+  <<(maybe_user_at(U))/binary,D/binary>>.
 
 -spec from_bin(binary()) -> jid().
 from_bin(Bin) when is_binary(Bin) ->
-    case parse_jid_elements(Bin) of
-        {U, D} -> #bare_jid{username = U, domain = D};
-        {U, D, R} -> #full_jid{username = U, domain = D, resource = R}
-    end.
+  case parse_jid_elements(Bin) of
+    {U, D} -> #bare_jid{username = U, domain = D};
+    {U, D, R} -> #full_jid{username = U, domain = D, resource = R}
+  end.
 
 -spec username(jid()) -> username().
 username(#full_jid{username = U}) -> U;
@@ -96,7 +98,7 @@ is_full_jid(#full_jid{}) -> true.
 
 -spec is_same_user(jid(), jid()) -> boolean().
 is_same_user(JID1, JID2) ->
-    bare(JID1) == bare(JID2).
+  bare(JID1) == bare(JID2).
 
 -spec is_same_resource(full_jid(), full_jid()) -> boolean().
 is_same_resource(#full_jid{} = JID, #full_jid{} = JID) -> true;
@@ -104,25 +106,25 @@ is_same_resource(#full_jid{} = _JID1, #full_jid{} = _JID2) -> false.
 
 -spec has_same_domain(jid(), jid()) -> boolean().
 has_same_domain(JID1, JID2) ->
-    domain(JID1) == domain(JID2).
+  domain(JID1) == domain(JID2).
 
 -spec parse_jid_elements(binary()) -> {username(), domain()} |
                                       {username(), domain(), resource()}.
 parse_jid_elements(Bin) ->
-    [User, Rest] = parse_user_part(Bin),
-    case binary:split(Rest, <<"/">>, [global]) of
-        [Domain] -> {User,Domain};
-        [Domain, Resource] -> {User,Domain,Resource};
-        _ -> throw(malformed_jid)
-    end.
+  [User, Rest] = parse_user_part(Bin),
+  case binary:split(Rest, <<"/">>, [global]) of
+    [Domain] -> {User,Domain};
+    [Domain, Resource] -> {User,Domain,Resource};
+    _ -> throw(malformed_jid)
+  end.
 
 parse_user_part(Bin) ->
-    case binary:split(Bin, <<"@">>, [global]) of
-        [Rest] -> [<<>>, Rest];
-        [<<>>, _Rest]  -> throw(malformed_jid); %% alone '@'
-        [_User, _Rest] = R -> R;
-        _ -> throw(malformed_jid) % more than one '@'
-    end.
+  case binary:split(Bin, <<"@">>, [global]) of
+    [Rest] -> [<<>>, Rest];
+    [<<>>, _Rest]  -> throw(malformed_jid); %% alone '@'
+    [_User, _Rest] = R -> R;
+    _ -> throw(malformed_jid) % more than one '@'
+  end.
 
 maybe_user_at(<<>>) -> <<>>;
 maybe_user_at(User) -> <<User/binary, "@">>.

--- a/src/x_message.erl
+++ b/src/x_message.erl
@@ -1,3 +1,5 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_message).
 -export([new/3, is_message/1]).
 
@@ -11,9 +13,9 @@
 
 -spec new(x_jid:jid(), x_jid:jid(), iolist()) -> x_message().
 new(From, To, _Body) ->
-    x_contract:check(From, fun x_jid:is_jid/1),
-    x_contract:check(To, fun x_jid:is_jid/1),
-    #x_message{from = From, to = To}.
+  x_contract:check(From, fun x_jid:is_jid/1),
+  x_contract:check(To, fun x_jid:is_jid/1),
+  #x_message{from = From, to = To}.
 
 -spec is_message(any()) -> boolean().
 is_message(#x_message{}) -> true;

--- a/src/x_namespacable.erl
+++ b/src/x_namespacable.erl
@@ -1,0 +1,10 @@
+-module(x_namespacable).
+
+-export([get_ns/1]).
+
+-callback get_ns(any()) -> x_ns:x_ns().
+
+-spec get_ns(tuple()) -> x_ns:x_ns().
+get_ns(Namespacable) ->
+  (x_implementation:module(Namespacable)):get_ns().
+

--- a/src/x_ns.erl
+++ b/src/x_ns.erl
@@ -1,0 +1,46 @@
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+-module(x_ns).
+
+-export([new/1,
+         to_attr/1,
+         is_ns/1,
+         equals/2,
+         is_subnamespace_of/2]).
+
+-include_lib("exml/include/exml.hrl").
+
+-record(x_ns, { uri = <<>> :: binary() }).
+
+-export_type([x_ns/0]).
+
+-type x_ns() :: #x_ns{}.
+
+-spec new(binary()) -> x_ns().
+new(Namespace) ->
+  x_contract:check(Namespace, fun is_binary/1),
+  #x_ns{uri = Namespace}.
+
+-spec to_attr(x_ns()) -> {<<_:40>>,  binary()}.
+to_attr(#x_ns{uri = U}) ->
+  {<<"xmlns">>, U}.
+
+-spec equals(x_ns(), x_ns()) -> boolean().
+equals(#x_ns{} = A, #x_ns{} = A) -> true;
+equals(#x_ns{}, #x_ns{}) -> false.
+
+-spec is_subnamespace_of(x_ns(), x_ns()) -> boolean().
+is_subnamespace_of(Namespace, BaseNamespace) ->
+  x_contract:check(Namespace, fun is_ns/1),
+  x_contract:check(BaseNamespace, fun is_ns/1),
+
+  N = erlang:byte_size(BaseNamespace#x_ns.uri),
+  Binaries = [Namespace#x_ns.uri, BaseNamespace#x_ns.uri],
+  case binary:longest_common_prefix(Binaries)  of
+    N -> true;
+    _ -> false
+  end.
+
+-spec is_ns(any()) -> boolean().
+is_ns(#x_ns{}) -> true;
+is_ns(_) -> false.

--- a/src/x_stream_end.erl
+++ b/src/x_stream_end.erl
@@ -25,7 +25,7 @@ new() ->
 is_stream_end(#x_stream_end{}) -> true;
 is_stream_end(_) -> false.
 
--spec to_exmlel(x_stream_end()) -> #xmlstreamend{}.
+-spec to_exmlel(x_stream_end()) -> exml_stream:stop().
 to_exmlel(#x_stream_end{}) ->
   #xmlstreamend{name = <<"stream:stream">>}.
 

--- a/src/x_stream_end.erl
+++ b/src/x_stream_end.erl
@@ -1,3 +1,5 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_stream_end).
 -include_lib("exml/include/exml_stream.hrl").
 
@@ -17,7 +19,7 @@
 
 -spec new() -> x_stream_end().
 new() ->
-    #x_stream_end{}.
+  #x_stream_end{}.
 
 -spec is_stream_end(any()) -> boolean().
 is_stream_end(#x_stream_end{}) -> true;
@@ -25,5 +27,5 @@ is_stream_end(_) -> false.
 
 -spec to_exmlel(x_stream_end()) -> #xmlstreamend{}.
 to_exmlel(#x_stream_end{}) ->
-    #xmlstreamend{name = <<"stream:stream">>}.
+  #xmlstreamend{name = <<"stream:stream">>}.
 

--- a/src/x_stream_features.erl
+++ b/src/x_stream_features.erl
@@ -23,7 +23,7 @@
 -record(complex_feature, {
           name :: binary(),
           ns :: x_ns:x_ns(),
-          children :: [xmlstreamelement()]}).
+          children :: [exml:element()]}).
 
 -record(x_stream_features, {features = [] :: [feature()]}).
 
@@ -46,7 +46,7 @@ new(#xmlel{name = <<"stream:features">>, children = C}) ->
 add(Features, FeatureName, FeatureNamespace) ->
   add(Features, FeatureName, FeatureNamespace, []).
 
--spec add(x_stream_features(), binary(), x_ns:x_ns(), [xmlstreamelement()]) ->
+-spec add(x_stream_features(), binary(), x_ns:x_ns(), [exml:element()]) ->
   x_stream_features().
 add(Features, FeatureName, FeatureNamespace, Subelements) ->
   case has_feature(Features, FeatureNamespace, FeatureName) of
@@ -69,7 +69,7 @@ has_feature(Features, Namespace, Name) ->
       end,
   1 == erlang:length(lists:filter(F, CurrentFeatures)).
 
--spec to_exmlel(tuple()) -> #xmlel{}.
+-spec to_exmlel(tuple()) -> exml_stream:element().
 to_exmlel(#x_stream_features{features = Features}) ->
   EXMLFeatures = lists:map(fun to_exmlel/1, Features),
   #xmlel{name = <<"stream:features">>, children = EXMLFeatures};
@@ -82,13 +82,13 @@ to_exmlel(#complex_feature{name = N, ns = Namespace, children = C}) ->
 feature(Name, NS) ->
   #simple_feature{name = Name, ns = NS}.
 
--spec feature(binary(), x_ns:x_ns(), [xmlstreamelement()]) -> feature().
+-spec feature(binary(), x_ns:x_ns(), [exml:element()]) -> feature().
 feature(Name, NS, []) ->
   feature(Name, NS);
 feature(Name, NS, SubEl) ->
   #complex_feature{name = Name, ns = NS, children = SubEl}.
 
--spec feature_from_exml(xmlstreamelement()) -> feature().
+-spec feature_from_exml(exml:element()) -> feature().
 feature_from_exml(#xmlel{name = Name, children = C} = El) ->
   NS = x_ns:new(exml_query:attr(El, <<"xmlns">>, <<>>)),
   feature(Name, NS, C).

--- a/src/x_stream_features.erl
+++ b/src/x_stream_features.erl
@@ -1,0 +1,94 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
+-module(x_stream_features).
+
+-include_lib("exml/include/exml.hrl").
+-include_lib("exml/include/exml_stream.hrl").
+
+%% convert to exml
+-behaviour(x_exmlable).
+-export([to_exmlel/1]).
+
+-export([new/0, new/1,
+         add/3, add/4,
+         has_feature/3
+        ]).
+
+-export_type([x_stream_features/0]).
+
+-record(simple_feature, {
+          name :: binary(),
+          ns :: x_ns:x_ns() }).
+
+-record(complex_feature, {
+          name :: binary(),
+          ns :: x_ns:x_ns(),
+          children :: [xmlstreamelement()]}).
+
+-record(x_stream_features, {features = [] :: [feature()]}).
+
+
+
+-type complex_feature() :: #complex_feature{}.
+-type simple_feature() :: #simple_feature{}.
+-type feature() :: simple_feature() | complex_feature().
+-type x_stream_features() :: #x_stream_features{}.
+
+
+new() ->
+  #x_stream_features{}.
+
+new(#xmlel{name = <<"stream:features">>, children = C}) ->
+  Features = lists:map(fun feature_from_exml/1, C),
+  #x_stream_features{ features = Features}.
+
+-spec add(x_stream_features(), binary(), x_ns:x_ns()) -> x_stream_features().
+add(Features, FeatureName, FeatureNamespace) ->
+  add(Features, FeatureName, FeatureNamespace, []).
+
+-spec add(x_stream_features(), binary(), x_ns:x_ns(), [xmlstreamelement()]) ->
+  x_stream_features().
+add(Features, FeatureName, FeatureNamespace, Subelements) ->
+  case has_feature(Features, FeatureNamespace, FeatureName) of
+    false ->
+      #x_stream_features{features = CurrentFeatures} = Features,
+      NewFeature = feature(FeatureName, FeatureNamespace, Subelements),
+      NewFeaturesList = CurrentFeatures ++ [NewFeature],
+      Features#x_stream_features{features = NewFeaturesList};
+    true ->
+      Features
+  end.
+
+-spec has_feature(x_stream_features(), x_ns:x_ns(), binary()) -> boolean().
+has_feature(Features, Namespace, Name) ->
+  #x_stream_features{features = CurrentFeatures} = Features,
+  F = fun(#simple_feature{ns = NS, name = N}) ->
+          N == Name andalso x_ns:equals(NS, Namespace);
+         (#complex_feature{ns = NS, name = N}) ->
+          N == Name andalso x_ns:equals(NS, Namespace)
+      end,
+  1 == erlang:length(lists:filter(F, CurrentFeatures)).
+
+-spec to_exmlel(tuple()) -> #xmlel{}.
+to_exmlel(#x_stream_features{features = Features}) ->
+  EXMLFeatures = lists:map(fun to_exmlel/1, Features),
+  #xmlel{name = <<"stream:features">>, children = EXMLFeatures};
+to_exmlel(#simple_feature{name = N, ns = Namespace}) ->
+  #xmlel{name = N, attrs = [x_ns:to_attr(Namespace)]};
+to_exmlel(#complex_feature{name = N, ns = Namespace, children = C}) ->
+  #xmlel{name = N, attrs = [x_ns:to_attr(Namespace)], children = C}.
+
+-spec feature(binary(), x_ns:x_ns()) -> simple_feature().
+feature(Name, NS) ->
+  #simple_feature{name = Name, ns = NS}.
+
+-spec feature(binary(), x_ns:x_ns(), [xmlstreamelement()]) -> feature().
+feature(Name, NS, []) ->
+  feature(Name, NS);
+feature(Name, NS, SubEl) ->
+  #complex_feature{name = Name, ns = NS, children = SubEl}.
+
+-spec feature_from_exml(xmlstreamelement()) -> feature().
+feature_from_exml(#xmlel{name = Name, children = C} = El) ->
+  NS = x_ns:new(exml_query:attr(El, <<"xmlns">>, <<>>)),
+  feature(Name, NS, C).

--- a/src/x_stream_start.erl
+++ b/src/x_stream_start.erl
@@ -31,7 +31,7 @@ new(Domain, Lang, Version) ->
 is_stream_start(#x_stream_start{}) -> true;
 is_stream_start(_) -> false.
 
--spec to_exmlel(x_stream_start()) -> #xmlstreamstart{}.
+-spec to_exmlel(x_stream_start()) -> exml_stream:start().
 to_exmlel(StreamStart) ->
   #x_stream_start{to = Domain, lang = Lang, version = Version} = StreamStart,
   Attrs = [{<<"to">>, Domain},

--- a/src/x_stream_start.erl
+++ b/src/x_stream_start.erl
@@ -1,3 +1,5 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_stream_start).
 -include_lib("exml/include/exml_stream.hrl").
 
@@ -19,11 +21,11 @@
 
 -spec new(x_jid:jid(), x:iso_639_1_lang(), float()) -> x_stream_start().
 new(Domain, Lang, Version) ->
-    x_contract:check(Domain, fun x_jid:is_jid/1),
-    %% TODO: check version and lang ?
-    #x_stream_start{to = x_jid:to_bin(Domain),
-                    lang = Lang,
-                    version = Version}.
+  x_contract:check(Domain, fun x_jid:is_jid/1),
+  %% TODO: check version and lang ?
+  #x_stream_start{to = x_jid:to_bin(Domain),
+                  lang = Lang,
+                  version = Version}.
 
 -spec is_stream_start(any()) -> boolean().
 is_stream_start(#x_stream_start{}) -> true;
@@ -31,8 +33,8 @@ is_stream_start(_) -> false.
 
 -spec to_exmlel(x_stream_start()) -> #xmlstreamstart{}.
 to_exmlel(StreamStart) ->
-    #x_stream_start{to = Domain, lang = Lang, version = Version} = StreamStart,
-    Attrs = [{<<"to">>, Domain},
-             {<<"xml:lang">>, erlang:atom_to_binary(Lang, utf8)},
-             {<<"version">>, float_to_binary(Version, [{decimals, 1}])}],
-    #xmlstreamstart{name = <<"stream:stream">>, attrs = Attrs}.
+  #x_stream_start{to = Domain, lang = Lang, version = Version} = StreamStart,
+  Attrs = [{<<"to">>, Domain},
+           {<<"xml:lang">>, erlang:atom_to_binary(Lang, utf8)},
+           {<<"version">>, float_to_binary(Version, [{decimals, 1}])}],
+  #xmlstreamstart{name = <<"stream:stream">>, attrs = Attrs}.

--- a/test/x_contract_tests.erl
+++ b/test/x_contract_tests.erl
@@ -1,31 +1,33 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_contract_tests).
 -include_lib("eunit/include/eunit.hrl").
 
 contract_passes_with_ok_test_()->
-    ?_assertEqual(ok,
-                 x_contract:check(1, fun is_number/1)).
+  ?_assertEqual(ok,
+                x_contract:check(1, fun is_number/1)).
 
 contract_fails_when_pred_returns_false_test_()->
-    Pred = fun is_number/1,
-    ?_assertError({contract_failed, [], {Pred, false}},
-                  x_contract:check([], Pred)).
+  Pred = fun is_number/1,
+  ?_assertError({contract_failed, [], {Pred, false}},
+                x_contract:check([], Pred)).
 
 contract_fails_when_pred_returns_non_boolean_test_()->
-    Pred = fun(_) -> ok end,
-    ?_assertError({contract_failed, [], {Pred, ok}},
-                  x_contract:check([], Pred)).
+  Pred = fun(_) -> ok end,
+  ?_assertError({contract_failed, [], {Pred, ok}},
+                x_contract:check([], Pred)).
 
 contract_fails_when_pred_crashes_1_test_()->
-    Pred = fun(x) -> true end,
-    ?_assertError({contract_failed, y, {Pred, {error, function_clause}}},
-                  x_contract:check(y, Pred)).
+  Pred = fun(x) -> true end,
+  ?_assertError({contract_failed, y, {Pred, {error, function_clause}}},
+                x_contract:check(y, Pred)).
 
 contract_fails_when_pred_crashes_2_test_()->
-    Pred = fun(L)-> length(L) == 1 end,
-    ?_assertError({contract_failed, y, {Pred, {error, badarg}}},
-                  x_contract:check(y, Pred)).
+  Pred = fun(L)-> length(L) == 1 end,
+  ?_assertError({contract_failed, y, {Pred, {error, badarg}}},
+                x_contract:check(y, Pred)).
 
 contract_fails_when_pred_crashes_3_test_()->
-    Pred = fun not_defined:anywhere/1,
-    ?_assertError({contract_failed, y, {Pred, {error, undef}}},
-                  x_contract:check(y, Pred)).
+  Pred = fun not_defined:anywhere/1,
+  ?_assertError({contract_failed, y, {Pred, {error, undef}}},
+                x_contract:check(y, Pred)).

--- a/test/x_jid_tests.erl
+++ b/test/x_jid_tests.erl
@@ -1,118 +1,120 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_jid_tests).
 
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 from_bin_to_bin_test_() ->
-    B = <<"hello@world.com">>,
-    ?_assertEqual(B,
-                  x_jid:to_bin(x_jid:from_bin(B))).
+  B = <<"hello@world.com">>,
+  ?_assertEqual(B,
+                x_jid:to_bin(x_jid:from_bin(B))).
 
 from_bin_to_bin_w_resource_test_() ->
-    B = <<"hello@world.com/pc">>,
-    ?_assertEqual(B,
-                  x_jid:to_bin(x_jid:from_bin(B))).
+  B = <<"hello@world.com/pc">>,
+  ?_assertEqual(B,
+                x_jid:to_bin(x_jid:from_bin(B))).
 
 from_bin_to_bin_host_only_test_() ->
-    B = <<"localhost">>,
-    ?_assertEqual(B,
-                  x_jid:to_bin(x_jid:from_bin(B))).
+  B = <<"localhost">>,
+  ?_assertEqual(B,
+                x_jid:to_bin(x_jid:from_bin(B))).
 
 from_bin_at_without_user_test_() ->
-    B = <<"@localhost">>,
-    ?_assertThrow(malformed_jid,x_jid:from_bin(B)).
+  B = <<"@localhost">>,
+  ?_assertThrow(malformed_jid,x_jid:from_bin(B)).
 
 from_bin_multiple_at_test_() ->
-    B = <<"pawel@pawel@localhost">>,
-    ?_assertThrow(malformed_jid, x_jid:from_bin(B)).
+  B = <<"pawel@pawel@localhost">>,
+  ?_assertThrow(malformed_jid, x_jid:from_bin(B)).
 
 from_bin_multiple_slashes_test_() ->
-    B = <<"pawel@kanku/res1/res2">>,
-    ?_assertThrow(malformed_jid, x_jid:from_bin(B)).
+  B = <<"pawel@kanku/res1/res2">>,
+  ?_assertThrow(malformed_jid, x_jid:from_bin(B)).
 
 to_bin_from_bin_test_() ->
-    Jid = x_jid:new(<<"super">>,<<"hero.com">>),
-    ?_assertEqual(Jid,
-                  x_jid:from_bin(x_jid:to_bin(Jid))).
+  Jid = x_jid:new(<<"super">>,<<"hero.com">>),
+  ?_assertEqual(Jid,
+                x_jid:from_bin(x_jid:to_bin(Jid))).
 
 to_bin_from_bin_w_resource_test_() ->
-    Jid = x_jid:new(<<"super">>,<<"hero.com">>,<<"batmobile">>),
-    ?_assertEqual(Jid,
-                  x_jid:from_bin(x_jid:to_bin(Jid))).
+  Jid = x_jid:new(<<"super">>,<<"hero.com">>,<<"batmobile">>),
+  ?_assertEqual(Jid,
+                x_jid:from_bin(x_jid:to_bin(Jid))).
 
 to_bin_from_bin_hostonly_test_() ->
-    Jid = x_jid:new(<<>>,<<"hero.com">>,<<"batmobile">>),
-    ?_assertEqual(Jid,
-                  x_jid:from_bin(x_jid:to_bin(Jid))).
+  Jid = x_jid:new(<<>>,<<"hero.com">>,<<"batmobile">>),
+  ?_assertEqual(Jid,
+                x_jid:from_bin(x_jid:to_bin(Jid))).
 
 same_resource_is_full_equality_test_() ->
-    J = x_jid:from_bin(<<"a@b.c/resource-1">>),
-    ?_assert(x_jid:is_same_resource(J,J)).
+  J = x_jid:from_bin(<<"a@b.c/resource-1">>),
+  ?_assert(x_jid:is_same_resource(J,J)).
 
 same_resource_is_false_for_same_user_different_resource_test_() ->
-    R1 = x_jid:from_bin(<<"a@b.c/resource-10">>),
-    R2 = x_jid:from_bin(<<"a@b.c/resource-99">>),
-    ?_assertNot(x_jid:is_same_resource(R1,R2)).
+  R1 = x_jid:from_bin(<<"a@b.c/resource-10">>),
+  R2 = x_jid:from_bin(<<"a@b.c/resource-99">>),
+  ?_assertNot(x_jid:is_same_resource(R1,R2)).
 
 same_resource_is_false_for_same_user_different_domain_test_() ->
-    R1 = x_jid:from_bin(<<"a@x.y/resource-1">>),
-    R2 = x_jid:from_bin(<<"a@b.c/resource-1">>),
-    ?_assertNot(x_jid:is_same_resource(R1,R2)).
+  R1 = x_jid:from_bin(<<"a@x.y/resource-1">>),
+  R2 = x_jid:from_bin(<<"a@b.c/resource-1">>),
+  ?_assertNot(x_jid:is_same_resource(R1,R2)).
 
 same_resource_is_false_for_different_different_same_domain_resource_test_() ->
-    R1 = x_jid:from_bin(<<"a@b.c/resource-1">>),
-    R2 = x_jid:from_bin(<<"z@b.c/resource-1">>),
-    ?_assertNot(x_jid:is_same_resource(R1,R2)).
+  R1 = x_jid:from_bin(<<"a@b.c/resource-1">>),
+  R2 = x_jid:from_bin(<<"z@b.c/resource-1">>),
+  ?_assertNot(x_jid:is_same_resource(R1,R2)).
 
 has_same_domain_is_true_if_domains_match_test_() ->
-    R1 = x_jid:from_bin(<<"a@b.c/resource-1">>),
-    R2 = x_jid:from_bin(<<"z@b.c/resource-99">>),
-    ?_assert(x_jid:has_same_domain(R1,R2)).
+  R1 = x_jid:from_bin(<<"a@b.c/resource-1">>),
+  R2 = x_jid:from_bin(<<"z@b.c/resource-99">>),
+  ?_assert(x_jid:has_same_domain(R1,R2)).
 
 has_same_domain_is_false_if_domains_differ_test_() ->
-    R1 = x_jid:from_bin(<<"a@b.c/resource-1">>),
-    R2 = x_jid:from_bin(<<"a@x.y/resource-1">>),
-    ?_assertNot(x_jid:has_same_domain(R1,R2)).
+  R1 = x_jid:from_bin(<<"a@b.c/resource-1">>),
+  R2 = x_jid:from_bin(<<"a@x.y/resource-1">>),
+  ?_assertNot(x_jid:has_same_domain(R1,R2)).
 
 bare_jid_decomposition_test() ->
-    property(new_bare_jid,
-             ?FORALL({U,D}, {user(), domain()},
-                     begin
-                         J = x_jid:new(U, D),
+  property(new_bare_jid,
+           ?FORALL({U,D}, {user(), domain()},
+                   begin
+                     J = x_jid:new(U, D),
 
-                         false == x_jid:is_full_jid(J) andalso
-                         true == x_jid:is_bare_jid(J) andalso
-                         U == x_jid:username(J) andalso
-                         D == x_jid:domain(J)
-                     end)).
+                     false == x_jid:is_full_jid(J) andalso
+                     true == x_jid:is_bare_jid(J) andalso
+                     U == x_jid:username(J) andalso
+                     D == x_jid:domain(J)
+                   end)).
 
 full_jid_decomposition_test() ->
-    property(new_full_jid,
-             ?FORALL({U,D,R}, {user(), domain(), resource()},
-                     begin
-                         J = x_jid:new(U, D, R),
+  property(new_full_jid,
+           ?FORALL({U,D,R}, {user(), domain(), resource()},
+                   begin
+                     J = x_jid:new(U, D, R),
 
-                         true == x_jid:is_full_jid(J) andalso
-                         false == x_jid:is_bare_jid(J) andalso
-                         U == x_jid:username(J) andalso
-                         D == x_jid:domain(J) andalso
-                         R == x_jid:resource(J)
-                     end)).
+                     true == x_jid:is_full_jid(J) andalso
+                     false == x_jid:is_bare_jid(J) andalso
+                     U == x_jid:username(J) andalso
+                     D == x_jid:domain(J) andalso
+                     R == x_jid:resource(J)
+                   end)).
 
 full_jid_to_bare_test() ->
-    property(full_to_bare,
-             ?FORALL({U,D,R}, {user(), domain(), resource()},
-                     begin
-                         J = x_jid:new(U, D, R),
-                         B = x_jid:bare(J),
-                         BB = x_jid:bare(B),
+  property(full_to_bare,
+           ?FORALL({U,D,R}, {user(), domain(), resource()},
+                   begin
+                     J = x_jid:new(U, D, R),
+                     B = x_jid:bare(J),
+                     BB = x_jid:bare(B),
 
-                         false == x_jid:is_bare_jid(J) andalso
-                         true == x_jid:is_bare_jid(B) andalso
-                         true == x_jid:is_bare_jid(BB) andalso
-                         U == x_jid:username(B) andalso
-                         D == x_jid:domain(B)
-                     end)).
+                     false == x_jid:is_bare_jid(J) andalso
+                     true == x_jid:is_bare_jid(B) andalso
+                     true == x_jid:is_bare_jid(BB) andalso
+                     U == x_jid:username(B) andalso
+                     D == x_jid:domain(B)
+                   end)).
 
 
 %serialization_test() ->
@@ -125,18 +127,18 @@ full_jid_to_bare_test() ->
 %
 %% types
 user() ->
-    ?SUCHTHAT(B, utf8(1023),
-              erlang:byte_size(B) < 1024).
+  ?SUCHTHAT(B, utf8(1023),
+            erlang:byte_size(B) < 1024).
 
 domain() ->
-    ?SUCHTHAT(B, utf8(1023), erlang:byte_size(B) < 1024 andalso
-              erlang:byte_size(B) < 1024).
+  ?SUCHTHAT(B, utf8(1023), erlang:byte_size(B) < 1024 andalso
+            erlang:byte_size(B) < 1024).
 
 resource() ->
-    ?SUCHTHAT(B, utf8(1023), erlang:byte_size(B) < 1024 andalso
-              erlang:byte_size(B) < 1024).
+  ?SUCHTHAT(B, utf8(1023), erlang:byte_size(B) < 1024 andalso
+            erlang:byte_size(B) < 1024).
 
 property(Name, Prop) ->
-    Props = proper:conjunction([{Name, Prop}]),
-    true = proper:quickcheck(Props, [verbose, long_result, {numtests, 100}]).
+  Props = proper:conjunction([{Name, Prop}]),
+  true = proper:quickcheck(Props, [verbose, long_result, {numtests, 100}]).
 

--- a/test/x_message_tests.erl
+++ b/test/x_message_tests.erl
@@ -1,3 +1,4 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
 %% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_message_tests).
 -include_lib("eunit/include/eunit.hrl").

--- a/test/x_ns_tests.erl
+++ b/test/x_ns_tests.erl
@@ -1,0 +1,31 @@
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+-module(x_ns_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+to_attr_test_() ->
+  NS = x_ns:new(<<"urn:pawel:0">>),
+  ?_assertEqual({<<"xmlns">>,<<"urn:pawel:0">>}, x_ns:to_attr(NS)).
+
+equality_test_() ->
+  N1 = x_ns:new(<<"urn:pawel:0">>),
+  N2 = x_ns:new(<<"urn:pawel:0">>),
+  ?_assertEqual(true, x_ns:equals(N1, N2)).
+
+pred_test_() ->
+  ?_assertEqual(false, x_ns:is_ns(undefined)).
+
+inequality_test_() ->
+  N1 = x_ns:new(<<"urn:pawel:0">>),
+  N2 = x_ns:new(<<"urn:pawel:1">>),
+  ?_assertEqual(false, x_ns:equals(N1, N2)).
+
+positive_subns_test_() ->
+  N1 = x_ns:new(<<"urn:pawel:0">>),
+  N2 = x_ns:new(<<"urn:pawel:0#admin">>),
+  ?_assertEqual(true, x_ns:is_subnamespace_of(N2, N1)).
+
+negative_subns_test_() ->
+  N1 = x_ns:new(<<"urn:pawel:0">>),
+  N2 = x_ns:new(<<"urn:pawel:0#admin">>),
+  ?_assertEqual(false, x_ns:is_subnamespace_of(N1, N2)).

--- a/test/x_stream_features_tests.erl
+++ b/test/x_stream_features_tests.erl
@@ -1,0 +1,70 @@
+%% -*- mode: erlang; erlang-indent-level: 2 -*- %%
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+-module(x_stream_features_tests).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("exml/include/exml.hrl").
+
+create_empty_features_test_() ->
+  Features = x_stream_features:new(),
+  Expected = <<"<stream:features/>">>,
+  ?_assertEqual(Expected, to_bin(Features)).
+
+append_to_empty_features_list_test_() ->
+  Features1 = x_stream_features:new(),
+  Features2 = x_stream_features:add(Features1, <<"sm">>, x_ns:new(<<"test">>)),
+  Expected = <<"<stream:features><sm xmlns='test'/></stream:features>">>,
+  ?_assertEqual(Expected, to_bin(Features2)).
+
+append_complex_feature_to_not_empty_list_test_() ->
+  Features1 = x_stream_features:new(),
+  Features2 = x_stream_features:add(Features1, <<"ms">>, x_ns:new(<<"hoax">>)),
+  NS = x_ns:new(<<"urn:madeup">>),
+  MechCdata = #xmlcdata{content = <<"SASL">>},
+  Mechanism = #xmlel{name = <<"mechanism">>, children = [MechCdata]},
+  Features3 = x_stream_features:add(Features2, <<"auth">>, NS, Mechanism),
+  Expected = <<"<stream:features>"
+                    "<ms xmlns='hoax'/>"
+                    "<auth xmlns='urn:madeup'>"
+                      "<mechanism>SASL</mechanism>"
+                    "</auth>"
+               "</stream:features>">>,
+  ?_assertEqual(Expected, to_bin(Features3)).
+
+should_not_add_the_same_feature_twice_test_() ->
+  Expected = <<"<stream:features>"
+                 "<ms xmlns='hoax'/>"
+               "</stream:features>">>,
+  Features1 = x_stream_features:new(),
+  Features2 = x_stream_features:add(Features1, <<"ms">>,
+                                    x_ns:new(<<"hoax">>)),
+  %% try with simple
+  Features3 = x_stream_features:add(Features2, <<"ms">>,
+                                    x_ns:new(<<"hoax">>)),
+  %% try with complex
+  Features4 = x_stream_features:add(Features3, <<"ms">>,
+                                    x_ns:new(<<"hoax">>),
+                                    #xmlel{name = <<"simple">>}),
+
+  ?_assertEqual(Expected, to_bin(Features4)).
+
+construct_features_from_stanza_test_() ->
+  Raw = <<"<stream:features xmlns:stream='http://etherx.jabber.org/streams'>"
+                    "<ms xmlns='hoax'/>"
+                    "<auth xmlns='urn:madeup'>"
+                      "<mechanism>SASL</mechanism>"
+                    "</auth>"
+          "</stream:features>">>,
+  {ok, Parsed} = exml:parse(Raw),
+  Features = x_stream_features:new(Parsed),
+  HoaxNS = x_ns:new(<<"hoax">>),
+  AuthNS = x_ns:new(<<"urn:madeup">>),
+  %% multiple properties
+  [
+   ?_assertEqual(true,  x_stream_features:has_feature(Features, AuthNS, <<"auth">>)),
+   ?_assertEqual(false,  x_stream_features:has_feature(Features, HoaxNS, <<"auth">>)),
+   ?_assertEqual(true,  x_stream_features:has_feature(Features, HoaxNS, <<"ms">>)),
+   ?_assertEqual(false, x_stream_features:has_feature(Features, HoaxNS, <<"sm">>))
+  ].
+
+to_bin(El) ->
+ exml:to_binary((x_exmlable:to_exmlel(El))).

--- a/test/x_stream_tests.erl
+++ b/test/x_stream_tests.erl
@@ -4,7 +4,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 stream_start_test_() ->
-  Expected  = <<"<stream:stream version='1.0' xml:lang='en' to='localhost'>">>,
+  Expected  = <<"<stream:stream to='localhost' xml:lang='en' version='1.0'>">>,
   Header = x_stream_start:new(x_jid:from_bin(<<"localhost">>), en, 1.0),
   ?_assertEqual(Expected, exml:to_binary((x_exmlable:to_exmlel(Header)))).
 

--- a/test/x_stream_tests.erl
+++ b/test/x_stream_tests.erl
@@ -1,28 +1,29 @@
+%% vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
 %% -*- mode: erlang; erlang-indent-level: 2 -*- %%
 -module(x_stream_tests).
 -include_lib("eunit/include/eunit.hrl").
 
 stream_start_test_() ->
-    Expected  = <<"<stream:stream version='1.0' xml:lang='en' to='localhost'>">>,
-    Header = x_stream_start:new(x_jid:from_bin(<<"localhost">>), en, 1.0),
-    ?_assertEqual(Expected, exml:to_binary((x_exmlable:to_exmlel(Header)))).
+  Expected  = <<"<stream:stream version='1.0' xml:lang='en' to='localhost'>">>,
+  Header = x_stream_start:new(x_jid:from_bin(<<"localhost">>), en, 1.0),
+  ?_assertEqual(Expected, exml:to_binary((x_exmlable:to_exmlel(Header)))).
 
 stream_end_test_() ->
-    Expected = <<"</stream:stream>">>,
-    Trailer = x_stream_end:new(),
-    ?_assertEqual(Expected, exml:to_binary(x_exmlable:to_exmlel(Trailer))).
+  Expected = <<"</stream:stream>">>,
+  Trailer = x_stream_end:new(),
+  ?_assertEqual(Expected, exml:to_binary(x_exmlable:to_exmlel(Trailer))).
 
 is_stream_start_accepts_valid_stream_start_test_() ->
-    S = x_stream_start:new(x_jid:from_bin(<<"localhost10.io">>), pl, 1.0),
-    ?_assertEqual(true, x_stream_start:is_stream_start(S)).
+  S = x_stream_start:new(x_jid:from_bin(<<"localhost10.io">>), pl, 1.0),
+  ?_assertEqual(true, x_stream_start:is_stream_start(S)).
 
 is_stream_end_accepts_valid_stream_end_test_() ->
-    ?_assertEqual(true, x_stream_end:is_stream_end(x_stream_end:new())).
+  ?_assertEqual(true, x_stream_end:is_stream_end(x_stream_end:new())).
 
 %% it is more like smoke test - I think it is a good candidate for proper
 is_stream_start_reject_invalid_terms_test_() ->
-    ?_assertEqual(false, x_stream_start:is_stream_start((x_stream_end:new()))).
+  ?_assertEqual(false, x_stream_start:is_stream_start((x_stream_end:new()))).
 
 is_stream_end_reject_invalid_terms_test_() ->
-    S = x_stream_start:new(x_jid:from_bin(<<"localhost44.io">>), pl, 2.0),
-    ?_assertEqual(false, x_stream_end:is_stream_end(S)).
+  S = x_stream_start:new(x_jid:from_bin(<<"localhost44.io">>), pl, 2.0),
+  ?_assertEqual(false, x_stream_end:is_stream_end(S)).


### PR DESCRIPTION
Hey @pzel, I have a problem with modelling features - elements of the features list.
I started with two types of feature:
- simple feature 

```
<startls xmlns="some-ns"/>
```
- complex feature:

```
<auth xmlns="another-ns">
   <mechanism>Plain</mechanism>
   <mechanism>Digest</mechanism>
</auth>
```

There are flaws, the `mechanism` elements are passed as unrestricted exml - I think it would be better to expect at least type ~ "exmlable", then we call the `to_exml` function on the incoming "thing", but the question is: how to do that? How can I define such type? Maybe introducing "feature behavior" would help, but what callbacks should I define? Moreover how to design the `get_feature`function, It can't return fixed number of types, otherwise every time programmer adds a new feature he/she is force to update this function's spec.  

On the other hand, maybe the current approach is OK? I think it is important question, because this situation may occur again in the future, for example, while designing IQ results, but they can be handled by each "xep module" that will provide `to_iq()` callback?
